### PR TITLE
Handling unloading properly

### DIFF
--- a/diagnostic_aggregator/CMakeLists.txt
+++ b/diagnostic_aggregator/CMakeLists.txt
@@ -48,6 +48,7 @@ target_link_libraries(analyzer_loader diagnostic_aggregator)
 if(CATKIN_ENABLE_TESTING)
   add_rostest(test/launch/test_agg.launch)
   add_rostest(test/launch/test_add_agg.launch)
+  add_rostest(test/launch/test_add_double_pub_remove.launch)
 
   # Test Analyzer loader
   add_rostest(test/launch/test_loader.launch)

--- a/diagnostic_aggregator/test/add_analyzers_test.py
+++ b/diagnostic_aggregator/test/add_analyzers_test.py
@@ -41,6 +41,7 @@ import threading
 from bondpy import bondpy
 from diagnostic_msgs.srv import AddDiagnostics
 from diagnostic_msgs.msg import DiagnosticArray, DiagnosticStatus
+import concurrent.futures
 
 PKG = 'diagnostic_aggregator'
 
@@ -73,9 +74,6 @@ class TestAddAnalyzer(unittest.TestCase):
                 self.agg_msgs[stat.name] = stat
 
     def add_analyzer(self):
-        target = open("../tititoto", 'w')
-        target.write("HI\n")
-        target.close()
         """Start a bond to the aggregator
         """
         self.bond = bondpy.Bond("/diagnostics_agg/bond", rospy.resolve_name(rospy.get_name()))
@@ -100,19 +98,19 @@ class TestAddAnalyzer(unittest.TestCase):
             DiagnosticStatus(name='primary', message='hello-primary'),
             DiagnosticStatus(name='secondary', message='hello-secondary')
         ]
-        self.pub.publish(arr)
+        #self.pub.publish(arr)
         #self.wait_for_agg()
         # the new aggregator data should contain the extra paths. At this point
         # the paths are probably still in the 'Other' group because the bond
         # hasn't been fully formed
-        with self._mutex:
-            agg_paths = [msg.name for name, msg in self.agg_msgs.iteritems()]
+        #with self._mutex:
+        #    agg_paths = [msg.name for name, msg in self.agg_msgs.iteritems()]
        #     self.assert_(all(expected in agg_paths for expected in self.expected))
 
-        rospy.sleep(rospy.Duration(1))  # wait a bit for the new items to move to the right group
+        #rospy.sleep(rospy.Duration(1))  # wait a bit for the new items to move to the right group
         arr.header.stamp = rospy.get_rostime()
         self.pub.publish(arr)  # publish again to get the correct groups to show OK
-        self.wait_for_agg()
+        #self.wait_for_agg()
 
         #for name, msg in self.agg_msgs.iteritems():
         #    if name in self.expected:  # should have just received messages on the analyzer
@@ -140,7 +138,11 @@ class TestAddAnalyzer(unittest.TestCase):
                 'Add Analyzers: add timed out while waiting for diagnostics_agg service, or ROS shutdown [{0}]'.format(
                     self.name))
 
-        self.wait_for_agg()
+        #self.wait_for_agg()
+
+    def loop_add_remove(self,id):
+        while (True):
+            self.add_remove(id)
 
     def test_add_agg(self):
         self.wait_for_agg()
@@ -151,13 +153,31 @@ class TestAddAnalyzer(unittest.TestCase):
             self.assert_(not any(expected in agg_paths for expected in self.expected))
             
         # add the new groups
-        while(True):
-            self.add_remove()
+        #self.add_remove(1)
+
+
+
+        #for i in range(0,2):
+        self.add_remove()
+        # arr = DiagnosticArray()
+        # arr.header.stamp = rospy.get_rostime()
+        # arr.status = [
+        #     DiagnosticStatus(name='primary', message='hello-primary'),
+        #     DiagnosticStatus(name='secondary', message='hello-secondary')
+        # ]
+        # self.pub.publish(arr)
+        # for i in range(0,nb_threads):
+        #     tid = th_pool.submit(self.add_remove,i)
+        #     thread_array.append(tid)
+
+        # for j in range(0,nb_threads):
+        #     thread_array[j].result()
+
 
         # the aggregator data should no longer contain the paths once the bond is shut down
-        with self._mutex:
-            agg_paths = [msg.name for name, msg in self.agg_msgs.iteritems()]
-            self.assert_(not any(expected in agg_paths for expected in self.expected))
+        # with self._mutex:
+        #     agg_paths = [msg.name for name, msg in self.agg_msgs.iteritems()]
+        #     self.assert_(not any(expected in agg_paths for expected in self.expected))
         
 if __name__ == '__main__':
     print 'SYS ARGS:', sys.argv

--- a/diagnostic_aggregator/test/add_analyzers_test.py
+++ b/diagnostic_aggregator/test/add_analyzers_test.py
@@ -56,6 +56,10 @@ class TestAddAnalyzer(unittest.TestCase):
         self._mutex = threading.Lock()
         self.agg_msgs = {}
 
+        self.add_diagnostics = None
+        self.name = rospy.get_name()
+        #self.namespace = None
+
         # put parameters in the node namespace so they can be read by the aggregator
         for params, ns in paramlist:
             rosparam.upload_params(rospy.get_name() + '/' + ns, params)
@@ -69,20 +73,74 @@ class TestAddAnalyzer(unittest.TestCase):
                 self.agg_msgs[stat.name] = stat
 
     def add_analyzer(self):
+        target = open("../tititoto", 'w')
+        target.write("HI\n")
+        target.close()
         """Start a bond to the aggregator
         """
         self.bond = bondpy.Bond("/diagnostics_agg/bond", rospy.resolve_name(rospy.get_name()))
         self.bond.start()
         rospy.wait_for_service('/diagnostics_agg/add_diagnostics', timeout=10)
-        add_diagnostics = rospy.ServiceProxy('/diagnostics_agg/add_diagnostics', AddDiagnostics)
+        self.add_diagnostics = rospy.ServiceProxy('/diagnostics_agg/add_diagnostics', AddDiagnostics)
         print(self.namespace)
-        resp = add_diagnostics(load_namespace=self.namespace)
+        resp = self.add_diagnostics(load_namespace=self.namespace)
         self.assert_(resp.success, 'Service call was unsuccessful: {0}'.format(resp.message))
 
     def wait_for_agg(self):
         self.agg_msgs = {}
         while not self.agg_msgs and not rospy.is_shutdown():
-            rospy.sleep(rospy.Duration(3))
+            rospy.sleep(rospy.Duration(1))
+
+    def add_remove(self):
+        self.add_analyzer()
+
+        arr = DiagnosticArray()
+        arr.header.stamp = rospy.get_rostime()
+        arr.status = [
+            DiagnosticStatus(name='primary', message='hello-primary'),
+            DiagnosticStatus(name='secondary', message='hello-secondary')
+        ]
+        self.pub.publish(arr)
+        #self.wait_for_agg()
+        # the new aggregator data should contain the extra paths. At this point
+        # the paths are probably still in the 'Other' group because the bond
+        # hasn't been fully formed
+        with self._mutex:
+            agg_paths = [msg.name for name, msg in self.agg_msgs.iteritems()]
+       #     self.assert_(all(expected in agg_paths for expected in self.expected))
+
+        rospy.sleep(rospy.Duration(1))  # wait a bit for the new items to move to the right group
+        arr.header.stamp = rospy.get_rostime()
+        self.pub.publish(arr)  # publish again to get the correct groups to show OK
+        self.wait_for_agg()
+
+        #for name, msg in self.agg_msgs.iteritems():
+        #    if name in self.expected:  # should have just received messages on the analyzer
+        #        self.assert_(msg.message == 'OK')
+
+        agg_paths = [msg.name for name, msg in self.agg_msgs.iteritems()]
+        #self.assert_(all(expected in agg_paths for expected in self.expected))
+
+        # self.bond.shutdown()
+
+        try:
+            # this will reverse the load if it is loaded on the other side
+            resp = self.add_diagnostics(load_namespace=self.namespace)
+            if resp.success:
+                rospy.loginfo(
+                    'Add Analyzers: successfully removed analyzers from the diagnostic aggregator [{0}]'.format(
+                        self.name))
+            else:
+                rospy.logerr('Add Analyzers: failed to remove analyzers on the diagnostic aggregator [{0}][{1}]'.format(
+                    self.name, resp.message))
+        except rospy.service.ServiceException:
+            rospy.logerr('Add Analyzers: unloading service returned failure [{0}]'.format(self.name))
+        except rospy.ROSException:
+            rospy.logerr(
+                'Add Analyzers: add timed out while waiting for diagnostics_agg service, or ROS shutdown [{0}]'.format(
+                    self.name))
+
+        self.wait_for_agg()
 
     def test_add_agg(self):
         self.wait_for_agg()
@@ -93,38 +151,9 @@ class TestAddAnalyzer(unittest.TestCase):
             self.assert_(not any(expected in agg_paths for expected in self.expected))
             
         # add the new groups
-        self.add_analyzer()
+        while(True):
+            self.add_remove()
 
-        arr = DiagnosticArray()
-        arr.header.stamp = rospy.get_rostime()
-        arr.status = [
-            DiagnosticStatus(name='primary', message='hello-primary'),
-            DiagnosticStatus(name='secondary', message='hello-secondary')
-        ]
-        self.pub.publish(arr)
-        self.wait_for_agg()
-        # the new aggregator data should contain the extra paths. At this point
-        # the paths are probably still in the 'Other' group because the bond
-        # hasn't been fully formed
-        with self._mutex:
-            agg_paths = [msg.name for name, msg in self.agg_msgs.iteritems()]
-            self.assert_(all(expected in agg_paths for expected in self.expected))
-
-        rospy.sleep(rospy.Duration(5)) # wait a bit for the new items to move to the right group
-        arr.header.stamp = rospy.get_rostime()
-        self.pub.publish(arr) # publish again to get the correct groups to show OK
-        self.wait_for_agg()
-
-        for name, msg in self.agg_msgs.iteritems():
-            if name in self.expected: # should have just received messages on the analyzer
-                self.assert_(msg.message == 'OK')
-                
-            agg_paths = [msg.name for name, msg in self.agg_msgs.iteritems()]
-            self.assert_(all(expected in agg_paths for expected in self.expected))
-                
-
-        self.bond.shutdown()
-        self.wait_for_agg()
         # the aggregator data should no longer contain the paths once the bond is shut down
         with self._mutex:
             agg_paths = [msg.name for name, msg in self.agg_msgs.iteritems()]

--- a/diagnostic_aggregator/test/launch/test_add_agg.launch
+++ b/diagnostic_aggregator/test/launch/test_add_agg.launch
@@ -1,12 +1,10 @@
 <launch>
-  <node pkg="diagnostic_aggregator" type="aggregator_node" name="diag_agg" output="screen" >
+  <node pkg="diagnostic_aggregator" type="aggregator_node" name="diag_agg" output="screen">
     <rosparam command="load" file="$(find diagnostic_aggregator)/test/simple_analyzers.yaml" />
   </node>
 
   <test test-name="add-test" pkg="diagnostic_aggregator" type="add_analyzers_test.py"
-        name="add_analyzers_test" args="$(find diagnostic_aggregator)/test/add_analyzers.yaml" time-limit="3600.0"/>
-
-
+        name="add_analyzers_test" args="$(find diagnostic_aggregator)/test/add_analyzers.yaml"/>
   <!-- <node pkg="diagnostic_aggregator" type="add_analyzers_test.py" -->
   <!--       name="add_analyzers_test" args="$(find diagnostic_aggregator)/test/add_analyzers.yaml"/> -->
 </launch>

--- a/diagnostic_aggregator/test/launch/test_add_agg.launch
+++ b/diagnostic_aggregator/test/launch/test_add_agg.launch
@@ -1,10 +1,12 @@
 <launch>
-  <node pkg="diagnostic_aggregator" type="aggregator_node" name="diag_agg" output="screen">
+  <node pkg="diagnostic_aggregator" type="aggregator_node" name="diag_agg" output="screen" >
     <rosparam command="load" file="$(find diagnostic_aggregator)/test/simple_analyzers.yaml" />
   </node>
 
   <test test-name="add-test" pkg="diagnostic_aggregator" type="add_analyzers_test.py"
-        name="add_analyzers_test" args="$(find diagnostic_aggregator)/test/add_analyzers.yaml"/>
+        name="add_analyzers_test" args="$(find diagnostic_aggregator)/test/add_analyzers.yaml" time-limit="3600.0"/>
+
+
   <!-- <node pkg="diagnostic_aggregator" type="add_analyzers_test.py" -->
   <!--       name="add_analyzers_test" args="$(find diagnostic_aggregator)/test/add_analyzers.yaml"/> -->
 </launch>

--- a/diagnostic_aggregator/test/launch/test_add_double_pub_remove.launch
+++ b/diagnostic_aggregator/test/launch/test_add_double_pub_remove.launch
@@ -1,0 +1,12 @@
+<launch>
+  <node pkg="diagnostic_aggregator" type="aggregator_node" name="diag_agg" output="screen" >
+    <rosparam command="load" file="$(find diagnostic_aggregator)/test/simple_analyzers.yaml" />
+  </node>
+
+  <test test-name="add-test" pkg="diagnostic_aggregator" type="add_analyzers_pub_remove_test.py"
+        name="add_analyzers_test" args="$(find diagnostic_aggregator)/test/add_analyzers.yaml" time-limit="60.0"/>
+
+
+  <!-- <node pkg="diagnostic_aggregator" type="add_analyzers_test.py" -->
+  <!--       name="add_analyzers_test" args="$(find diagnostic_aggregator)/test/add_analyzers.yaml"/> -->
+</launch>

--- a/diagnostic_aggregator/test/launch/test_script_add.launch
+++ b/diagnostic_aggregator/test/launch/test_script_add.launch
@@ -1,3 +1,3 @@
 <launch>
-  <node pkg="diagnostic_aggregator" type="add_analyzers" name="add_analyzers" args="$(find diagnostic_aggregator)/test/multiple_match_analyzers.yaml"/>
+  <node pkg="diagnostic_aggregator" type="add_analyzers" name="add_analyzers" args="$(find diagnostic_aggregator)/test/multiple_match_analyzers.yaml" output="screen"/>
 </launch>


### PR DESCRIPTION
 Added a new test

This simple test add an analyzer to an existing diagnostic aggregator,
(if the diagnostic agregator does not exist the test will fail)
instantly after adding return success a messagne will be published to the
diagnostic aggregator.
Right after afer publishing the analyzer will be removed from the diagnostic
aggregator

This test fails in 2 ways
--> Trying to remove the analyser will result in a [WARNING] message
"Trying to remove an analyzer wich didn't exist"
even if the adding analyzer to the group has been "successfull".
--> The test will never finish and sometimes will stay locked in
tcpros_service.py wich will never raise timeout exception.